### PR TITLE
ci(validate): removes dep validation and renames pr title rule

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -11,7 +11,7 @@ permissions:
   contents: read # for checkout
 
 jobs:
-  lint:
+  validate-pr-title:
     runs-on: ubuntu-latest
     permissions:
       statuses: write

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -67,17 +67,3 @@ jobs:
           cache: "pnpm"
           node-version: ${{ matrix.node-version }}
       - run: pnpm run compile
-  verify-dependencies:
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        node-version: ["16.x", "18.x", "20.x"]
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      - name: Setup Node.js
-        uses: actions/setup-node@v3
-        with:
-          cache: "pnpm"
-          node-version: ${{ matrix.node-version }}
-      - run: pnpm run compile

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "dev": "vitest --watch",
     "build": "pnpm run compile && vite build",
     "compile": "tsc",
+    "lint": "eslint",
     "test": "vitest --watch=false"
   },
   "devDependencies": {


### PR DESCRIPTION
I accidentally pushed the dependency validation rule, which was a dupe of the compilation rule.  There was also overlap of the PR title validation rule, which should be fixed now.