### PR TITLE
ci(validate): drops support for node 16

### DIFF
--- a/.github/composite-workflows/pnpm-script-base/action.yml
+++ b/.github/composite-workflows/pnpm-script-base/action.yml
@@ -1,5 +1,5 @@
-name: Setup Pnpm
-description: Setup node and pnpm
+name: Base Pnpm Script Action
+description: Setup everything to run a pnpm script
 inputs:
   node-version:
     description: the version of Node to use
@@ -8,6 +8,8 @@ inputs:
 runs:
   using: composite
   steps:
+    - name: Checkout
+      uses: actions/checkout@v4
     - name: Install dependencies
       uses: pnpm/action-setup@v2
       with:

--- a/.github/composite-workflows/pnpm-script-base/action.yml
+++ b/.github/composite-workflows/pnpm-script-base/action.yml
@@ -8,8 +8,6 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Checkout
-      uses: actions/checkout@v4
     - name: Install dependencies
       uses: pnpm/action-setup@v2
       with:

--- a/.github/composite-workflows/setup-pnpm/action.yml
+++ b/.github/composite-workflows/setup-pnpm/action.yml
@@ -1,0 +1,21 @@
+name: Setup Pnpm
+description: Setup node and pnpm
+inputs:
+  node-version:
+    description: the version of Node to use
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Install dependencies
+      uses: pnpm/action-setup@v2
+      with:
+        version: 8
+        run_install: |
+          - recursive: true
+    - name: Setup Node.js
+      uses: actions/setup-node@v3
+      with:
+        cache: "pnpm"
+        node-version: ${{ matrix.node-version }}

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -13,6 +13,8 @@ jobs:
       matrix:
         node-version: ["18.x", "20.x"]
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
       - name: Setup Script Runner
         uses: ./.github/composite-workflows/pnpm-script-base
         with:
@@ -24,6 +26,8 @@ jobs:
       matrix:
         node-version: ["18.x", "20.x"]
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
       - name: Setup Script Runner
         uses: ./.github/composite-workflows/pnpm-script-base
         with:
@@ -35,6 +39,8 @@ jobs:
       matrix:
         node-version: ["18.x", "20.x"]
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
       - name: Setup Script Runner
         uses: ./.github/composite-workflows/pnpm-script-base
         with:

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,6 +1,6 @@
 name: CI
 on:
-  push:
+  pull_request:
     branches:
       - release/v*
       - main

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -11,59 +11,38 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: ["16.x", "18.x", "20.x"]
+        node-version: ["18.x", "20.x"]
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Install dependencies
-        uses: pnpm/action-setup@v2
+      - name: Setup Pnpm
+        uses: ./.github/composite-workflows/setup-pnpm
         with:
-          version: 8
-          run_install: |
-            - recursive: true
-      - name: Setup Node.js
-        uses: actions/setup-node@v3
-        with:
-          cache: "pnpm"
           node-version: ${{ matrix.node-version }}
       - run: pnpm run lint
   test:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: ["16.x", "18.x", "20.x"]
+        node-version: ["18.x", "20.x"]
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Install dependencies
-        uses: pnpm/action-setup@v2
+      - name: Setup Pnpm
+        uses: ./.github/composite-workflows/setup-pnpm
         with:
-          version: 8
-          run_install: |
-            - recursive: true
-      - name: Setup Node.js
-        uses: actions/setup-node@v3
-        with:
-          cache: "pnpm"
           node-version: ${{ matrix.node-version }}
       - run: pnpm test
   compile:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: ["16.x", "18.x", "20.x"]
+        node-version: ["18.x", "20.x"]
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Install dependencies
-        uses: pnpm/action-setup@v2
+      - name: Setup Pnpm
+        uses: ./.github/composite-workflows/setup-pnpm
         with:
-          version: 8
-          run_install: |
-            - recursive: true
-      - name: Setup Node.js
-        uses: actions/setup-node@v3
-        with:
-          cache: "pnpm"
           node-version: ${{ matrix.node-version }}
       - run: pnpm run compile

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -13,10 +13,8 @@ jobs:
       matrix:
         node-version: ["18.x", "20.x"]
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      - name: Setup Pnpm
-        uses: ./.github/composite-workflows/setup-pnpm
+      - name: Setup Script Runner
+        uses: ./.github/composite-workflows/pnpm-script-base
         with:
           node-version: ${{ matrix.node-version }}
       - run: pnpm run lint
@@ -26,10 +24,8 @@ jobs:
       matrix:
         node-version: ["18.x", "20.x"]
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      - name: Setup Pnpm
-        uses: ./.github/composite-workflows/setup-pnpm
+      - name: Setup Script Runner
+        uses: ./.github/composite-workflows/pnpm-script-base
         with:
           node-version: ${{ matrix.node-version }}
       - run: pnpm test
@@ -39,10 +35,8 @@ jobs:
       matrix:
         node-version: ["18.x", "20.x"]
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      - name: Setup Pnpm
-        uses: ./.github/composite-workflows/setup-pnpm
+      - name: Setup Script Runner
+        uses: ./.github/composite-workflows/pnpm-script-base
         with:
           node-version: ${{ matrix.node-version }}
       - run: pnpm run compile


### PR DESCRIPTION
This PR drops support for Node 16, which is at EOL.  It also extracts all setup for script-running actions into a composite action so that I don't have to maintain things in multiple places.