### PR TITLE
ci(release): removes git plugin from semantic release

### DIFF
--- a/release.config.js
+++ b/release.config.js
@@ -41,7 +41,6 @@ const config = {
     "@semantic-release/release-notes-generator",
     "@semantic-release/changelog",
     "@semantic-release/npm",
-    "@semantic-release/git",
     "@semantic-release/github",
   ],
 };


### PR DESCRIPTION
Dropping the git plugin from semantic release because of this comment: https://github.com/semantic-release/git/issues/477